### PR TITLE
Fixing accessToken expiration and updating Moment.add() deprecation

### DIFF
--- a/lib/services/accessTokens.js
+++ b/lib/services/accessTokens.js
@@ -24,9 +24,9 @@ var create = function(principal, options, callback) {
         options = {};
     }
 
-    var expiration = moment().add('days', core.config.access_token_lifetime).toDate();
+    var expiration = moment().add(core.config.access_token_lifetime, 'days');
     if (options.expires) {
-        expiration = new Date(options.expires);
+        expiration = moment(new Date(options.expires));
     }
 
     var accessToken = new core.models.AccessToken({
@@ -36,7 +36,7 @@ var create = function(principal, options, callback) {
 
     accessToken.token = jwt.sign({
         iss: principal.id
-    }, core.config.access_token_signing_key, { expiresInMinutes: 60 * 24 * core.config.access_token_lifetime });
+    }, core.config.access_token_signing_key, { expiresInMinutes: (expiration.milliseconds() - moment().milliseconds())/(1000 * 60) });
 
     accessToken.save(callback);
 };

--- a/lib/services/apiKeys.js
+++ b/lib/services/apiKeys.js
@@ -73,7 +73,6 @@ var create = function(authzPrincipal, apiKey, callback) {
 
         apiKey.save(function(err) {
             // kick off creating a personalized image for this key.
-
             getRedisClient().rpush('images.build', JSON.stringify({ key: apiKey.key }), function(err) {
                 if (callback) return callback(err, apiKey);
             });

--- a/lib/services/messages.js
+++ b/lib/services/messages.js
@@ -294,7 +294,7 @@ var removeOne = function(principal, message, callback) {
 
 var translate = function(message) {
     if (!message.index_until) {
-        message.index_until = moment().add('days', core.config.default_message_indexed_lifetime).toDate();
+        message.index_until = moment().add(core.config.default_message_indexed_lifetime, 'days').toDate();
     }
 
     if (message.index_until === 'forever') {

--- a/lib/services/permissions.js
+++ b/lib/services/permissions.js
@@ -161,7 +161,7 @@ var permissionsFor = function(principalId, callback) {
     find(core.services.principals.servicePrincipal, query, { sort: { priority: 1 } }, function(err, permissions) {
         if (err) return callback(err);
 
-        core.config.cache_provider.set('permissions', principalId, permissions, moment().add('minutes', core.config.permissions_for_cache_lifetime_minutes).toDate(), function(err) {
+        core.config.cache_provider.set('permissions', principalId, permissions, moment().add(core.config.permissions_for_cache_lifetime_minutes, 'minutes').toDate(), function(err) {
             return callback(err, permissions);
         });
     });

--- a/lib/services/principals.js
+++ b/lib/services/principals.js
@@ -347,7 +347,7 @@ var findById = function(authzPrincipal, id, callback) {
 
         core.log.debug("principals: setting cache entry for " + cacheKey);
 
-        core.config.cache_provider.set('principals', cacheKey, principal.toObject(), moment().add('minutes', core.config.principals_cache_lifetime_minutes).toDate(), function(err) {
+        core.config.cache_provider.set('principals', cacheKey, principal.toObject(), moment().add(core.config.principals_cache_lifetime_minutes, 'minutes').toDate(), function(err) {
             return callback(err, principal);
         });
     });

--- a/lib/services/subscriptions.js
+++ b/lib/services/subscriptions.js
@@ -156,7 +156,7 @@ var findByPrincipal = function(authPrincipal, principalId, options, callback) {
         if (err) return callback(err);
 
         core.log.debug("subscriptions: setting cache entry for " + cacheKey + ": " + subscriptions.length);
-        core.config.cache_provider.set('subscriptions', cacheKey, subscriptions,  moment().add('days', 1).toDate(), function(err) {
+        core.config.cache_provider.set('subscriptions', cacheKey, subscriptions,  moment().add(1, 'days').toDate(), function(err) {
             return callback(err, subscriptions);
         });
     });

--- a/test/unit/accessToken.js
+++ b/test/unit/accessToken.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+  , moment = require('moment')
   , core = require('../../lib');
 
 describe('accessToken service', function() {
@@ -27,5 +28,23 @@ describe('accessToken service', function() {
                 });
             });
         });
+    });
+    it('can create a token with the correct default expiration (1 day)', function(done) {
+        core.services.accessTokens.create(core.fixtures.models.principals.anotherUser, function(err, accessToken) {
+            assert(!err);
+            var expires = moment(accessToken.expiration);
+            var oneDayFromNow = moment().add(1, 'days');
+            assert((oneDayFromNow - expires) == (60 * 60 * 24 * 1000));
+            done();
+        });    
+    });
+    it('can create a token with a custom expiration', function(done) {
+        core.services.accessTokens.create(core.fixtures.models.principals.anotherUser, { expires: moment().add(30, 'days') }, function(err, accessToken) {
+            assert(!err);
+            var expires = moment(accessToken.expiration);
+            var thirtyDaysFromNow = moment().add(30, 'days');
+            assert((thirtyDaysFromNow - expires) == (30 * 60 * 60 * 24 * 1000));
+            done();
+        });    
     });
 });

--- a/test/unit/messages.js
+++ b/test/unit/messages.js
@@ -168,7 +168,7 @@ describe('messages service', function() {
             core.services.blobs.create(core.fixtures.models.principals.device, blob, stream, function(err, blob) {
                 assert(!err);
 
-                var oneMinuteFromNow = moment().add('minutes', 1).toDate();
+                var oneMinuteFromNow = moment().add(1, 'minutes').toDate();
 
                 var message = new core.models.Message({
                     from: core.fixtures.models.principals.device.id,

--- a/test/unit/subscriptions.js
+++ b/test/unit/subscriptions.js
@@ -240,7 +240,7 @@ describe('subscriptions service', function() {
             permanent: true,
             principal: core.services.principals.servicePrincipal,
             type: "message",
-            last_receive: moment().add('days', -5).toDate()
+            last_receive: moment().add(-5, 'days').toDate()
         });
 
         core.services.subscriptions.findOrCreate(permSub, function(err, permSub) {
@@ -253,7 +253,7 @@ describe('subscriptions service', function() {
                 type: "message",
                 permanent: false,
                 name: core.utils.uuid(),
-                last_receive: moment().add('days', -5).toDate()
+                last_receive: moment().add(-5, 'days').toDate()
             });
 
             core.services.subscriptions.findOrCreate(sessionSub, function(err, sessionSub) {


### PR DESCRIPTION
I added two tests to verify accessToken expiration is working and updated the moment.add() calls to eliminate the deprecation warnings.

