### PR TITLE
Fixed delimiter to allow valid keys in flattened messages.

### DIFF
--- a/lib/services/messages.js
+++ b/lib/services/messages.js
@@ -321,7 +321,8 @@ var translate = function(message) {
 
 var flatten = function(message, opt) {
     var options = {
-        safe : true
+        safe : true,
+        delimiter: '__'        
     };
     
     for (var attrname in opt) { options[attrname] = opt[attrname]; }


### PR DESCRIPTION
This is important so we have valid keys, the delimter is __ (to keep _'s safe in names)